### PR TITLE
fix: allow duplicate map keys

### DIFF
--- a/dir/test_anchor_keys.yml
+++ b/dir/test_anchor_keys.yml
@@ -1,0 +1,15 @@
+.names:
+  plan: &plan_name "test"
+  build: &build_name "build"
+
+*plan_name :
+  script:
+    echo "Plan"
+
+*build_name :
+  script:
+    echo "Build"
+
+test:
+  script:
+    echo "Build"

--- a/reader/script_reader.go
+++ b/reader/script_reader.go
@@ -122,7 +122,7 @@ func (d ScriptDecoder) decodeAstFile(astFile *ast.File) ([]ScriptBlock, error) {
 }
 
 func readFile(file string) (*ast.File, error) {
-	astFile, err := parser.ParseFile(file, parser.ParseComments)
+	astFile, err := parser.ParseFile(file, parser.ParseComments, parser.AllowDuplicateMapKey())
 	if err != nil {
 		return nil, fmt.Errorf("unable to parse file %s: %w", file, err)
 	}


### PR DESCRIPTION
current workaround for supporting anchors as map keys